### PR TITLE
Unify env variable name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/App.tsx
+++ b/App.tsx
@@ -127,7 +127,7 @@ const App: React.FC = () => {
           )}
         </main>
         <footer className="text-center mt-12 text-gray-500 text-sm">
-            <p>Powered by Google Gemini. Ensure your API_KEY environment variable is configured.</p>
+            <p>Powered by Google Gemini. Ensure your GEMINI_API_KEY environment variable is configured.</p>
             <p>&copy; {new Date().getFullYear()} AI Code Reviewer</p>
         </footer>
       </div>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Gemini Code Reviewer — это инструмент для автоматизи
    ```
 3. Создайте файл `.env.local` в корневой директории и добавьте ваш API ключ:
    ```env
-   API_KEY=your_gemini_api_key_here
+   GEMINI_API_KEY=your_gemini_api_key_here
    ```
 
 ## Запуск приложения

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -18,12 +18,12 @@ export const reviewCode = async (
   language: Language,
   reviewLanguage: ReviewLanguage // New parameter
 ): Promise<StructuredReview> => {
-  if (!process.env.API_KEY) {
-    console.error("API_KEY environment variable is not set.");
-    throw new Error("Gemini API Key is missing. Please ensure the API_KEY environment variable is correctly set.");
+  if (!process.env.GEMINI_API_KEY) {
+    console.error("GEMINI_API_KEY environment variable is not set.");
+    throw new Error("Gemini API Key is missing. Please ensure the GEMINI_API_KEY environment variable is correctly set.");
   }
 
-  const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+  const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
   const programmingLanguageLabel = getLanguageLabel(language);
   const feedbackLanguageLabel = getReviewLanguageLabel(reviewLanguage);
 
@@ -148,7 +148,7 @@ Your JSON Review (strictly in the format above, with all text in ${feedbackLangu
   } catch (error) {
     console.error('Error calling Gemini API:', error);
     if (error instanceof Error && error.message.includes("API key not valid")) {
-        throw new Error("Invalid Gemini API Key. Please check your API_KEY environment variable.");
+        throw new Error("Invalid Gemini API Key. Please check your GEMINI_API_KEY environment variable.");
     }
     if (error instanceof Error) {
         throw new Error(`Failed to get review from Gemini (review language: ${feedbackLanguageLabel}): ${error.message}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- rename API_KEY to GEMINI_API_KEY in docs and source
- update Vite config to expose GEMINI_API_KEY
- add `.env.example` with the new variable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850421f31fc8321902e5c3525491009