### PR TITLE
Remove redundant importmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,21 +26,9 @@
         background: #718096; /* dark-500 */
       }
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.1.0",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react/": "https://esm.sh/react@^19.1.0/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.1.0"
-  }
-}
-</script>
-</head>
+  </head>
   <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
-<link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>


### PR DESCRIPTION
## Summary
- remove the unnecessary importmap block
- clean up leftover script tags

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68504244f3f48321becfe20330238e58