### PR TITLE
Add basic lint script and minimal tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+tests-dist

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    rules: {}
+  }
+];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "npm run build-tests && node --test tests-dist/tests",
+    "build-tests": "npx tsc constants.ts services/geminiService.ts tests/*.ts --module ESNext --moduleResolution bundler --target ES2020 --skipLibCheck true --outDir tests-dist"
   },
   "dependencies": {
     "@google/genai": "^1.1.0",

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
-import { Language, StructuredReview, ReviewLanguage } from '../types';
-import { SUPPORTED_LANGUAGES, SUPPORTED_REVIEW_LANGUAGES } from '../constants';
+import { Language, StructuredReview, ReviewLanguage } from '../types.js';
+import { SUPPORTED_LANGUAGES, SUPPORTED_REVIEW_LANGUAGES } from '../constants.js';
 
 const getLanguageLabel = (languageValue: Language): string => {
   const langObj = SUPPORTED_LANGUAGES.find(lang => lang.value === languageValue);

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,7 @@
+import { SUPPORTED_LANGUAGES } from '../constants.js';
+import * as assert from 'node:assert';
+import test from 'node:test';
+
+test('SUPPORTED_LANGUAGES includes JavaScript', () => {
+  assert.ok(SUPPORTED_LANGUAGES.some(lang => lang.value === 'javascript'));
+});

--- a/tests/geminiService.test.ts
+++ b/tests/geminiService.test.ts
@@ -1,0 +1,15 @@
+import { reviewCode } from '../services/geminiService.js';
+import * as assert from 'node:assert';
+import test from 'node:test';
+
+// Ensure environment variable is not set for this test
+const oldKey = process.env.API_KEY;
+delete process.env.API_KEY;
+
+test('reviewCode throws when API_KEY is missing', async () => {
+  await assert.rejects(() => reviewCode('console.log("hi")', 'javascript', 'en'));
+});
+
+if (oldKey) {
+  process.env.API_KEY = oldKey;
+}


### PR DESCRIPTION
## Summary
- add minimal `eslint` config and ignore file
- create simple Node.js tests for constants and gemini service
- add scripts for linting and testing
- tweak service imports for Node ESM

## Testing
- `npm run lint` *(fails: ESLint plugins missing)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68504268ddb0832182b710972dfe5f66