### PR TITLE
Add simple i18n with RU/EN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+\ntests-dist/

--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useCallback } from 'react';
 import { CodeInput } from './components/CodeInput';
 import { LanguageSelector } from './components/LanguageSelector';
-import { ReviewLanguageSelector } from './components/ReviewLanguageSelector'; // New import
+import { ReviewLanguageSelector } from './components/ReviewLanguageSelector';
+import { UILanguageSelector } from './components/UILanguageSelector';
 import { ReviewOutput } from './components/ReviewOutput';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { ErrorMessage } from './components/ErrorMessage';
 import { reviewCode } from './services/geminiService';
-import { SUPPORTED_LANGUAGES, SUPPORTED_REVIEW_LANGUAGES } from './constants'; // Import review languages
-import { Language, StructuredReview, ReviewLanguage } from './types'; // Import ReviewLanguage
+import { SUPPORTED_LANGUAGES, SUPPORTED_REVIEW_LANGUAGES, SUPPORTED_UI_LANGUAGES } from './constants';
+import { Language, StructuredReview, ReviewLanguage, UILanguage } from './types';
+import { useI18n } from './i18n';
 
 const App: React.FC = () => {
   const [code, setCode] = useState<string>('');
@@ -16,10 +18,11 @@ const App: React.FC = () => {
   const [review, setReview] = useState<StructuredReview | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const { t, language: uiLanguage, setLanguage: setUiLanguage } = useI18n();
 
   const handleSubmit = useCallback(async () => {
     if (!code.trim()) {
-      setError('Please enter some code to review.');
+      setError(t('enterCode'));
       return;
     }
     setError(null);
@@ -33,7 +36,7 @@ const App: React.FC = () => {
       if (err instanceof Error) {
         setError(err.message);
       } else {
-        setError('An unknown error occurred.');
+        setError(t('unknownError'));
       }
       console.error("Review Error:", err);
     } finally {
@@ -53,13 +56,20 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center p-4 md:p-8 selection:bg-sky-700 selection:text-white">
       <div className="w-full max-w-4xl">
-        <header className="mb-8 text-center">
+        <header className="mb-8 text-center space-y-4">
           <h1 className="text-4xl md:text-5xl font-bold text-sky-400">
-            Gemini Code Reviewer
+            {t('appTitle')}
           </h1>
-          <p className="text-gray-400 mt-2 text-lg">
-            Get AI-powered feedback on your code.
+          <p className="text-gray-400 text-lg">
+            {t('appSubtitle')}
           </p>
+          <div className="max-w-xs mx-auto">
+            <UILanguageSelector
+              value={uiLanguage as UILanguage}
+              onChange={(e) => setUiLanguage(e.target.value as UILanguage)}
+              languages={SUPPORTED_UI_LANGUAGES}
+            />
+          </div>
         </header>
 
         <main className="bg-gray-800 shadow-2xl rounded-lg p-6 md:p-8">
@@ -69,12 +79,14 @@ const App: React.FC = () => {
               onChange={(e) => setLanguage(e.target.value as Language)}
               languages={SUPPORTED_LANGUAGES}
               disabled={isLoading}
+              label={t('selectLanguage')}
             />
-            <ReviewLanguageSelector // Add the new selector
+            <ReviewLanguageSelector
               value={reviewLanguage}
               onChange={(e) => setReviewLanguage(e.target.value as ReviewLanguage)}
               languages={SUPPORTED_REVIEW_LANGUAGES}
               disabled={isLoading}
+              label={t('selectReviewLanguage')}
             />
             <div className="flex items-end space-x-3 md:col-start-3"> {/* Buttons aligned to the end of this grid cell */}
               <button
@@ -86,10 +98,10 @@ const App: React.FC = () => {
                 {isLoading ? (
                   <>
                     <LoadingSpinner small />
-                    <span className="ml-2">Reviewing...</span>
+                    <span className="ml-2">{t('reviewing')}</span>
                   </>
                 ) : (
-                  'Review Code'
+                  {t('reviewButton')}
                 )}
               </button>
               <button
@@ -98,7 +110,7 @@ const App: React.FC = () => {
                 className="w-full sm:w-auto flex-grow bg-gray-600 hover:bg-gray-500 text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-opacity-75 disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Clear code input and review feedback"
               >
-                Clear
+                {t('clearButton')}
               </button>
             </div>
           </div>
@@ -106,7 +118,7 @@ const App: React.FC = () => {
           <CodeInput
             value={code}
             onChange={(e) => setCode(e.target.value)}
-            placeholder={`Paste your ${SUPPORTED_LANGUAGES.find(l => l.value === language)?.label || 'code'} here...`}
+            placeholder={t('codePlaceholder', SUPPORTED_LANGUAGES.find(l => l.value === language)?.label || 'code')}
             aria-label="Code input area"
           />
 
@@ -115,8 +127,8 @@ const App: React.FC = () => {
           {isLoading && !review && (
             <div className="mt-6 flex flex-col items-center justify-center text-gray-400 p-8 border-2 border-dashed border-gray-700 rounded-lg" aria-live="polite">
               <LoadingSpinner />
-              <p className="mt-4 text-lg">Analyzing your code with Gemini...</p>
-              <p className="text-sm text-gray-500">This might take a few moments.</p>
+              <p className="mt-4 text-lg">{t('analyzing')}</p>
+              <p className="text-sm text-gray-500">{t('mightTake')}</p>
             </div>
           )}
           
@@ -127,8 +139,8 @@ const App: React.FC = () => {
           )}
         </main>
         <footer className="text-center mt-12 text-gray-500 text-sm">
-            <p>Powered by Google Gemini. Ensure your GEMINI_API_KEY environment variable is configured.</p>
-            <p>&copy; {new Date().getFullYear()} AI Code Reviewer</p>
+            <p>{t('poweredBy')}</p>
+            <p>{t('footer', new Date().getFullYear())}</p>
         </footer>
       </div>
     </div>

--- a/components/ErrorMessage.tsx
+++ b/components/ErrorMessage.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { useI18n } from '../i18n';
 
 interface ErrorMessageProps {
   message: string;
@@ -7,6 +8,7 @@ interface ErrorMessageProps {
 }
 
 export const ErrorMessage: React.FC<ErrorMessageProps> = ({ message, onClose }) => {
+  const { t } = useI18n();
   if (!message) return null;
 
   return (
@@ -14,13 +16,13 @@ export const ErrorMessage: React.FC<ErrorMessageProps> = ({ message, onClose }) 
       className="bg-red-700 border border-red-600 text-red-100 px-4 py-3 rounded-lg relative my-4 shadow-md"
       role="alert"
     >
-      <strong className="font-bold">Error: </strong>
+      <strong className="font-bold">{t('error')}: </strong>
       <span className="block sm:inline">{message}</span>
       {onClose && (
          <button
             onClick={onClose}
             className="absolute top-0 bottom-0 right-0 px-4 py-3 text-red-200 hover:text-white"
-            aria-label="Close error message"
+            aria-label={t('close')}
           >
             <svg className="fill-current h-6 w-6" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
           </button>

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -6,13 +6,14 @@ interface LanguageSelectorProps {
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   languages: LanguageOption[];
   disabled?: boolean;
+  label?: string;
 }
 
-export const LanguageSelector: React.FC<LanguageSelectorProps> = ({ value, onChange, languages, disabled }) => {
+export const LanguageSelector: React.FC<LanguageSelectorProps> = ({ value, onChange, languages, disabled, label }) => {
   return (
     <div>
       <label htmlFor="language-select" className="block text-sm font-medium text-gray-300 mb-1">
-        Select Language
+        {label || 'Select Language'}
       </label>
       <select
         id="language-select"

--- a/components/ReviewLanguageSelector.tsx
+++ b/components/ReviewLanguageSelector.tsx
@@ -6,13 +6,14 @@ interface ReviewLanguageSelectorProps {
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   languages: ReviewLanguageOption[];
   disabled?: boolean;
+  label?: string;
 }
 
-export const ReviewLanguageSelector: React.FC<ReviewLanguageSelectorProps> = ({ value, onChange, languages, disabled }) => {
+export const ReviewLanguageSelector: React.FC<ReviewLanguageSelectorProps> = ({ value, onChange, languages, disabled, label }) => {
   return (
     <div>
       <label htmlFor="review-language-select" className="block text-sm font-medium text-gray-300 mb-1">
-        Select Review Language
+        {label || 'Select Review Language'}
       </label>
       <select
         id="review-language-select"

--- a/components/ReviewOutput.tsx
+++ b/components/ReviewOutput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StructuredReview, ReviewSection, ReviewPoint } from '../types';
+import { useI18n } from '../i18n';
 
 interface ReviewOutputProps {
   review: StructuredReview | null;
@@ -48,10 +49,12 @@ const CodeBlock: React.FC<{ code?: string; language?: string; title?: string }> 
 
 
 export const ReviewOutput: React.FC<ReviewOutputProps> = ({ review }) => {
+  const { t } = useI18n();
+
   if (!review) {
     return (
       <div className="bg-gray-800 p-6 border border-gray-700 rounded-lg shadow-inner min-h-[100px] flex items-center justify-center">
-        <p className="text-gray-400">No review data available.</p>
+        <p className="text-gray-400">{t('noReview')}</p>
       </div>
     );
   }
@@ -69,13 +72,13 @@ export const ReviewOutput: React.FC<ReviewOutputProps> = ({ review }) => {
   return (
     <div className="bg-gray-800 p-4 md:p-6 border border-gray-700 rounded-lg shadow-inner text-gray-200 space-y-6">
       <h2 className="text-3xl font-semibold text-sky-400 mb-4 border-b border-gray-700 pb-3">
-        Code Review Feedback
+        {t('feedbackTitle')}
         {review.languageDetected && <span className="text-lg text-gray-400 ml-2">({review.languageDetected})</span>}
       </h2>
 
       {review.overallSummary && (
         <section aria-labelledby="overall-summary-heading">
-          <h3 id="overall-summary-heading" className="text-xl font-semibold text-sky-300 mb-2">Overall Summary</h3>
+          <h3 id="overall-summary-heading" className="text-xl font-semibold text-sky-300 mb-2">{t('overallSummary')}</h3>
           <p className="text-gray-300 leading-relaxed">{renderDescription(review.overallSummary)}</p>
         </section>
       )}
@@ -112,7 +115,7 @@ export const ReviewOutput: React.FC<ReviewOutputProps> = ({ review }) => {
 
       {review.finalThoughts && (
         <section aria-labelledby="final-thoughts-heading" className="pt-4 border-t border-gray-700">
-          <h3 id="final-thoughts-heading" className="text-xl font-semibold text-sky-300 mb-2">Final Thoughts</h3>
+          <h3 id="final-thoughts-heading" className="text-xl font-semibold text-sky-300 mb-2">{t('finalThoughts')}</h3>
           <p className="text-gray-300 leading-relaxed">{renderDescription(review.finalThoughts)}</p>
         </section>
       )}

--- a/components/UILanguageSelector.tsx
+++ b/components/UILanguageSelector.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { UILanguageOption, UILanguage } from '../types';
+
+interface UILanguageSelectorProps {
+  value: UILanguage;
+  onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  languages: UILanguageOption[];
+  disabled?: boolean;
+  label?: string;
+}
+
+export const UILanguageSelector: React.FC<UILanguageSelectorProps> = ({ value, onChange, languages, disabled, label }) => {
+  return (
+    <div>
+      <label htmlFor="ui-language-select" className="block text-sm font-medium text-gray-300 mb-1">
+        {label || 'Interface Language'}
+      </label>
+      <select
+        id="ui-language-select"
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        className="w-full bg-gray-700 border border-gray-600 text-gray-100 py-2 px-3 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition-colors duration-150 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {languages.map((lang) => (
+          <option key={lang.value} value={lang.value} className="bg-gray-700 text-gray-100">
+            {lang.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 
-import { LanguageOption, ReviewLanguageOption } from './types';
+import { LanguageOption, ReviewLanguageOption, UILanguageOption } from './types';
 
 export const SUPPORTED_LANGUAGES: LanguageOption[] = [
   { value: 'javascript', label: 'JavaScript' },
@@ -28,4 +28,9 @@ export const SUPPORTED_REVIEW_LANGUAGES: ReviewLanguageOption[] = [
   { value: 'de', label: 'Deutsch (German)' },
   { value: 'fr', label: 'Français (French)' },
   { value: 'zh', label: '中文 (Chinese)' },
+];
+
+export const SUPPORTED_UI_LANGUAGES: UILanguageOption[] = [
+  { value: 'en', label: 'English' },
+  { value: 'ru', label: 'Русский' },
 ];

--- a/i18n.tsx
+++ b/i18n.tsx
@@ -1,0 +1,89 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { UILanguage } from './types';
+
+interface Translations {
+  [key: string]: string | ((...args: any[]) => string);
+}
+
+const dictionaries: Record<UILanguage, Translations> = {
+  en: {
+    appTitle: 'Gemini Code Reviewer',
+    appSubtitle: 'Get AI-powered feedback on your code.',
+    selectLanguage: 'Select Language',
+    selectReviewLanguage: 'Select Review Language',
+    selectUILanguage: 'Interface Language',
+    reviewButton: 'Review Code',
+    clearButton: 'Clear',
+    reviewing: 'Reviewing...',
+    enterCode: 'Please enter some code to review.',
+    analyzing: 'Analyzing your code with Gemini...',
+    mightTake: 'This might take a few moments.',
+    codePlaceholder: (lang: string) => `Paste your ${lang} here...`,
+    noReview: 'No review data available.',
+    unknownError: 'An unknown error occurred.',
+    feedbackTitle: 'Code Review Feedback',
+    overallSummary: 'Overall Summary',
+    finalThoughts: 'Final Thoughts',
+    poweredBy: 'Powered by Google Gemini. Ensure your GEMINI_API_KEY environment variable is configured.',
+    footer: (year: number) => `© ${year} AI Code Reviewer`,
+    error: 'Error',
+    close: 'Close',
+  },
+  ru: {
+    appTitle: 'Рецензент кода Gemini',
+    appSubtitle: 'Получите анализ вашего кода при помощи ИИ.',
+    selectLanguage: 'Выберите язык кода',
+    selectReviewLanguage: 'Выберите язык рецензии',
+    selectUILanguage: 'Язык интерфейса',
+    reviewButton: 'Проверить код',
+    clearButton: 'Очистить',
+    reviewing: 'Проверяем...',
+    enterCode: 'Пожалуйста, вставьте код для рецензии.',
+    analyzing: 'Анализируем ваш код с помощью Gemini...',
+    mightTake: 'Это может занять некоторое время.',
+    codePlaceholder: (lang: string) => `Вставьте ваш ${lang} сюда...`,
+    noReview: 'Нет данных для рецензии.',
+    unknownError: 'Произошла неизвестная ошибка.',
+    feedbackTitle: 'Результаты проверки кода',
+    overallSummary: 'Общий итог',
+    finalThoughts: 'Заключение',
+    poweredBy: 'Работает на Google Gemini. Убедитесь, что переменная окружения GEMINI_API_KEY настроена.',
+    footer: (year: number) => `© ${year} Рецензент кода AI`,
+    error: 'Ошибка',
+    close: 'Закрыть',
+  }
+};
+
+interface I18nContextProps {
+  language: UILanguage;
+  setLanguage: (lang: UILanguage) => void;
+  t: (key: keyof Translations, ...args: any[]) => string;
+}
+
+const I18nContext = createContext<I18nContextProps | undefined>(undefined);
+
+export const I18nProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [language, setLanguage] = useState<UILanguage>('en');
+
+  const t = (key: keyof Translations, ...args: any[]) => {
+    const entry = dictionaries[language][key];
+    if (typeof entry === 'function') {
+      return (entry as (...args: any[]) => string)(...args);
+    }
+    return entry as string;
+  };
+
+  return (
+    <I18nContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export const useI18n = () => {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within an I18nProvider');
+  }
+  return context;
+};

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { I18nProvider } from './i18n';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,9 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </React.StrictMode>
 );
+

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,13 @@ export interface ReviewLanguageOption {
   label: string;
 }
 
+export type UILanguage = 'en' | 'ru';
+
+export interface UILanguageOption {
+  value: UILanguage;
+  label: string;
+}
+
 // New types for structured review
 export interface ReviewPoint {
   type: 'finding' | 'suggestion' | 'positive' | 'question';


### PR DESCRIPTION
## Summary
- implement `I18nProvider` with English and Russian dictionaries
- add UI language switcher and connect to App header
- translate labels, buttons and messages across components
- expose supported UI languages in constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685049ed5bf08321a526e36f1e21c8a5