### PR TITLE
Fix missing label for UI language select

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -68,6 +68,7 @@ const App: React.FC = () => {
               value={uiLanguage as UILanguage}
               onChange={(e) => setUiLanguage(e.target.value as UILanguage)}
               languages={SUPPORTED_UI_LANGUAGES}
+              label={t('selectUILanguage')}
             />
           </div>
         </header>


### PR DESCRIPTION
## Summary
- add a `label` prop when rendering `UILanguageSelector`

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6850545ee3e08321aafdffadc3ce41dc