### PR TITLE
Update env var in tests

### DIFF
--- a/tests/geminiService.test.ts
+++ b/tests/geminiService.test.ts
@@ -3,13 +3,13 @@ import * as assert from 'node:assert';
 import test from 'node:test';
 
 // Ensure environment variable is not set for this test
-const oldKey = process.env.API_KEY;
-delete process.env.API_KEY;
+const oldKey = process.env.GEMINI_API_KEY;
+delete process.env.GEMINI_API_KEY;
 
-test('reviewCode throws when API_KEY is missing', async () => {
+test('reviewCode throws when GEMINI_API_KEY is missing', async () => {
   await assert.rejects(() => reviewCode('console.log("hi")', 'javascript', 'en'));
 });
 
 if (oldKey) {
-  process.env.API_KEY = oldKey;
+  process.env.GEMINI_API_KEY = oldKey;
 }


### PR DESCRIPTION
## Summary
- adjust tests to use `process.env.GEMINI_API_KEY`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_685049e0f094832188fc66f7d74a9408